### PR TITLE
Trim Mentoring & Workshops lists

### DIFF
--- a/src/data/mentoring.json
+++ b/src/data/mentoring.json
@@ -1,79 +1,25 @@
 {
   "source": "Advocu — Google Developer Experts (Mentoring activities)",
   "fetchedOn": "2026-05-19",
-  "count": 12,
+  "count": 5,
   "items": [
-    {
-      "title": "Mentoring an old class fellow about AI Tools and Coding",
-      "date": "2026-04-18",
-      "attendees": 1,
-      "location": null,
-      "summary": "Mentored a Canada-based mechanical engineer on AI Studio and Antigravity for vibe coding.",
-      "tags": ["AI - AI Studio", "AI - Gemini"],
-      "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/108dd4d2-371f-46a9-8c5d-969eb0f949f9"
-    },
-    {
-      "title": "School Project Chat for career as AI Specialist",
-      "date": "2025-11-18",
-      "attendees": 1,
-      "location": null,
-      "summary": "Mentored polytechnic students on starting a career as AI programmers/specialists.",
-      "tags": ["AI"],
-      "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/3de404cb-2b03-4724-8938-afd907df9196"
-    },
     {
       "title": "Google AI First Accelerator Singapore",
       "date": "2025-06-17",
       "attendees": 13,
       "location": "Singapore",
       "summary": "Mentored AI-first founders across healthcare, education, hospitality and automation on architecture, model selection, deployment and scaling.",
-      "tags": ["AI", "AI - Agents", "AI - Gemini", "Android - Gemini Nano", "AI - Gemma", "AI - Generative AI", "AI - ML Engineering (MLOps)", "AI - On-Device AI"],
+      "tags": [
+        "AI",
+        "AI - Agents",
+        "AI - Gemini",
+        "Android - Gemini Nano",
+        "AI - Gemma",
+        "AI - Generative AI",
+        "AI - ML Engineering (MLOps)",
+        "AI - On-Device AI"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/3391e297-86d3-4767-ad4c-7ce805f2567a"
-    },
-    {
-      "title": "Google for Startups Mentoring (AI First SG): Dimuto",
-      "date": "2024-05-14",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "GfS AI-First accelerator mentoring — DiMuto, an AI-driven global AgriTrade ecosystem.",
-      "tags": ["AI - Generative AI"],
-      "image": null
-    },
-    {
-      "title": "Google for Startups Mentoring (AI First SG): Rabbit",
-      "date": "2024-05-09",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "GfS AI-First accelerator mentoring — Rabbit, Google Cloud optimization for data and platform engineers.",
-      "tags": ["AI - Generative AI", "Google Cloud"],
-      "image": null
-    },
-    {
-      "title": "Google for Startups Mentoring (AI First SG): Ailiverse",
-      "date": "2024-05-07",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "GfS AI-First accelerator mentoring — Ailiverse, a generative-AI startup turning text into high-quality video.",
-      "tags": ["AI - Generative AI"],
-      "image": null
-    },
-    {
-      "title": "Google for Startups Mentoring (AI First SG): Storybrain",
-      "date": "2024-05-07",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "GfS AI-First accelerator mentoring — StoryBrain, a model generating adaptive media and interfaces.",
-      "tags": ["AI - Generative AI"],
-      "image": null
-    },
-    {
-      "title": "Google for Startups Mentoring (AI First SG): C2 Carbon Sync",
-      "date": "2024-05-07",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "GfS AI-First accelerator mentoring — C2 Carbon Sync, enabling the transition to carbon neutrality through technology.",
-      "tags": ["AI - Generative AI", "AI", "Vision API"],
-      "image": null
     },
     {
       "title": "Mentoring Session for 2024 Solution Challenge TOP 100 teams: Glow Alarm",
@@ -81,7 +27,9 @@
       "attendees": 3,
       "location": null,
       "summary": "Reviewed submission documents for the Glow Alarm team in the 2024 Solution Challenge Top 100.",
-      "tags": ["Android"],
+      "tags": [
+        "Android"
+      ],
       "image": null
     },
     {
@@ -90,7 +38,10 @@
       "attendees": 3,
       "location": null,
       "summary": "Reviewed system architecture and sustainability impact for the WhyFlood team in the 2024 Solution Challenge Top 100.",
-      "tags": ["AI", "UX / UI Design"],
+      "tags": [
+        "AI",
+        "UX / UI Design"
+      ],
       "image": null
     },
     {
@@ -99,7 +50,11 @@
       "attendees": 3,
       "location": null,
       "summary": "Gave detailed feedback on the EPAS team's Arduino-based idea and reward system in the 2024 Solution Challenge Top 100.",
-      "tags": ["AI", "Dart - Flutter", "UX / UI Design"],
+      "tags": [
+        "AI",
+        "Dart - Flutter",
+        "UX / UI Design"
+      ],
       "image": null
     },
     {
@@ -108,7 +63,10 @@
       "attendees": 3,
       "location": null,
       "summary": "Advised the Combus team on moving bus number-plate recognition to a real-time video stream and reducing response time, in the 2024 Solution Challenge Top 100.",
-      "tags": ["Vision API", "AI"],
+      "tags": [
+        "Vision API",
+        "AI"
+      ],
       "image": null
     }
   ]

--- a/src/data/workshops.json
+++ b/src/data/workshops.json
@@ -1,7 +1,7 @@
 {
   "source": "Advocu — Google Developer Experts (Workshop activities)",
   "fetchedOn": "2026-05-19",
-  "count": 20,
+  "count": 14,
   "items": [
     {
       "title": "Facilitator at Build AI agents with Google Agent Development Kit Lab",
@@ -9,7 +9,11 @@
       "attendees": 10,
       "location": "Singapore",
       "summary": "Hands-on lab on building AI agents with the Google Agent Development Kit (ADK).",
-      "tags": ["AI - Agent Development Kit (ADK)", "AI - Gemini", "AI - Agents"],
+      "tags": [
+        "AI - Agent Development Kit (ADK)",
+        "AI - Gemini",
+        "AI - Agents"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/c2988d9a-50ab-4502-80d1-c107768f85dc"
     },
     {
@@ -18,7 +22,14 @@
       "attendees": 55,
       "location": null,
       "summary": "Interactive session guiding students from simple prompts to multi-step AI agent behaviors with Google Gemini.",
-      "tags": ["AI - Gemini", "AI - Agent Development Kit (ADK)", "AI - Vertex AI", "AI - AI Studio", "AI - Agents", "AI - Generative AI"],
+      "tags": [
+        "AI - Gemini",
+        "AI - Agent Development Kit (ADK)",
+        "AI - Vertex AI",
+        "AI - AI Studio",
+        "AI - Agents",
+        "AI - Generative AI"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/d037c299-b311-4dc3-9daa-84ead56339b8"
     },
     {
@@ -27,7 +38,14 @@
       "attendees": 50,
       "location": "Singapore",
       "summary": "Hands-on workshop on Google's latest Gemini updates and the Agent framework.",
-      "tags": ["AI - Agent Development Kit (ADK)", "AI - AI Studio", "AI - Gemini", "AI - Agents", "AI - Generative AI", "AI - Vertex AI"],
+      "tags": [
+        "AI - Agent Development Kit (ADK)",
+        "AI - AI Studio",
+        "AI - Gemini",
+        "AI - Agents",
+        "AI - Generative AI",
+        "AI - Vertex AI"
+      ],
       "image": null
     },
     {
@@ -36,7 +54,15 @@
       "attendees": 20,
       "location": null,
       "summary": "Building the next generation of Android apps with Gemini after Google I/O announcements.",
-      "tags": ["AI - AI Studio", "AI - Gemini", "AI", "Firebase", "Android", "Android - Android Studio", "ML Products - Vertex AI"],
+      "tags": [
+        "AI - AI Studio",
+        "AI - Gemini",
+        "AI",
+        "Firebase",
+        "Android",
+        "Android - Android Studio",
+        "ML Products - Vertex AI"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/8c08a283-902d-4fd6-8307-8c58fa4ec72a"
     },
     {
@@ -45,25 +71,12 @@
       "attendees": 20,
       "location": null,
       "summary": "Demos building apps with Gemini for Android for GDSC members at Monash University Malaysia.",
-      "tags": ["Android", "AI - Gemini", "Android - Android Studio", "AI - AI Studio"],
-      "image": null
-    },
-    {
-      "title": "Google For Startups Accelerator (AI First) Discovery Call with Jaz",
-      "date": "2024-04-25",
-      "attendees": 3,
-      "location": null,
-      "summary": "GfS AI-first accelerator discovery call with Jaz, a next-gen accounting & finance platform.",
-      "tags": ["AI"],
-      "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/2a70120a-7b57-42fc-9c7a-1bd283adf2fa"
-    },
-    {
-      "title": "Google For Startups Accelerator (AI First) Discovery Call with Rabbit",
-      "date": "2024-04-22",
-      "attendees": 3,
-      "location": null,
-      "summary": "GfS AI-first accelerator discovery call with Rabbit, a Google Cloud optimization platform.",
-      "tags": ["AI", "AI - Generative AI"],
+      "tags": [
+        "Android",
+        "AI - Gemini",
+        "Android - Android Studio",
+        "AI - AI Studio"
+      ],
       "image": null
     },
     {
@@ -72,7 +85,9 @@
       "attendees": 50,
       "location": "Singapore",
       "summary": "Facilitator for the Build with AI workshop, Singapore.",
-      "tags": ["AI - Generative AI"],
+      "tags": [
+        "AI - Generative AI"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/images/6597d5c3b52eaef4e46a602e/activity-images/ef100778-91a7-467a-95eb-9d45428c2c2c"
     },
     {
@@ -81,44 +96,12 @@
       "attendees": 23,
       "location": null,
       "summary": "Introduction to building Generative AI apps for Android.",
-      "tags": ["Generic Android", "AI - Generative AI", "Android"],
+      "tags": [
+        "Generic Android",
+        "AI - Generative AI",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2024/01/22/0a82ffef-5ee9-4e94-a90f-11d49b5b8d5b.jpeg"
-    },
-    {
-      "title": "Google for Startups Accelerator: Southeast Asia - PasarMikro",
-      "date": "2023-03-08",
-      "attendees": 3,
-      "location": "Singapore",
-      "summary": "Mentoring South East Asia and Pakistan startups at a bootcamp held in Google's Singapore office.",
-      "tags": ["Generic Android", "Android - App Architecture & Arch Components", "Android"],
-      "image": null
-    },
-    {
-      "title": "Google for Startups Accelerator: Southeast Asia - Docosan",
-      "date": "2023-02-07",
-      "attendees": 2,
-      "location": "Singapore",
-      "summary": "Mentoring South East Asia and Pakistan startups at a bootcamp held in Google's Singapore office.",
-      "tags": ["Generic Android", "Android - App Architecture & Arch Components", "Android"],
-      "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2023/03/24/f564a1eb-9edd-4425-835a-109534eba578.jpg"
-    },
-    {
-      "title": "Google for Startups Accelerator: Southeast Asia - Noice",
-      "date": "2023-02-07",
-      "attendees": 2,
-      "location": "Singapore",
-      "summary": "Mentoring South East Asia and Pakistan startups at a bootcamp held in Google's Singapore office.",
-      "tags": ["Generic Android", "Android - App Architecture & Arch Components", "Android"],
-      "image": null
-    },
-    {
-      "title": "Women Developers Academy South-east Asia 2022",
-      "date": "2022-04-24",
-      "attendees": 1,
-      "location": null,
-      "summary": "Helping women in tech build the skills and confidence to become tech presenters and speakers.",
-      "tags": ["Generic Android", "Android"],
-      "image": null
     },
     {
       "title": "Women Developer Academy Southeast-Asia 2021",
@@ -126,7 +109,10 @@
       "attendees": 2,
       "location": null,
       "summary": "Helping women in tech build the skills and confidence to become tech presenters and speakers (Jun–Jul 2021).",
-      "tags": ["Generic Android", "Android"],
+      "tags": [
+        "Generic Android",
+        "Android"
+      ],
       "image": null
     },
     {
@@ -135,7 +121,10 @@
       "attendees": 200,
       "location": null,
       "summary": "Getting started with Kotlin for Android development.",
-      "tags": ["Android - Kotlin", "Android"],
+      "tags": [
+        "Android - Kotlin",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2021/04/22/7bfa175b-f2de-4473-ae8e-6c2a1fb60e00.png"
     },
     {
@@ -144,7 +133,12 @@
       "attendees": 100,
       "location": "Quetta, Pakistan",
       "summary": "Deep dive into Kotlin and modern Android architecture — two sessions and a codelab.",
-      "tags": ["Android - Kotlin", "Android - Android Studio", "Android - Jetpack", "Android"],
+      "tags": [
+        "Android - Kotlin",
+        "Android - Android Studio",
+        "Android - Jetpack",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2020/01/20/ec643ba93b53cee3250c.jpg"
     },
     {
@@ -153,7 +147,11 @@
       "attendees": 20,
       "location": "Singapore",
       "summary": "One-day Startup Jam for seed-stage startups — product sprint and tech case studies, Android focus.",
-      "tags": ["Generic Android", "UX App Review", "Android"],
+      "tags": [
+        "Generic Android",
+        "UX App Review",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2019/09/13/369e8dbf1c66aaedc8ba.jpeg",
       "post": "/posts/google-startup-jam-2019/"
     },
@@ -163,7 +161,12 @@
       "attendees": 23,
       "location": "Singapore",
       "summary": "Hands-on codelab: Navigation Architecture Component and WorkManager.",
-      "tags": ["Android - Jetpack", "Android - Android Studio", "Android - Kotlin", "Android"],
+      "tags": [
+        "Android - Jetpack",
+        "Android - Android Studio",
+        "Android - Kotlin",
+        "Android"
+      ],
       "image": null
     },
     {
@@ -172,7 +175,10 @@
       "attendees": 15,
       "location": "Jakarta, Indonesia",
       "summary": "Day-long hackathon with 15 finalist solutions for 5 Indonesian industry challenges.",
-      "tags": ["Generic Android", "Android"],
+      "tags": [
+        "Generic Android",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2019/01/16/88a129f1e46487d53d20.jpg"
     },
     {
@@ -181,7 +187,12 @@
       "attendees": 40,
       "location": "Puerto Princesa, Philippines",
       "summary": "Teaching how to build Android apps using Kotlin.",
-      "tags": ["Android - Kotlin", "Android - Android Studio", "Android - Android Auto", "Android"],
+      "tags": [
+        "Android - Kotlin",
+        "Android - Android Studio",
+        "Android - Android Auto",
+        "Android"
+      ],
       "image": "https://storage.googleapis.com/advocu-app/gde/activity-photos/2018/08/14/19b244f0c5728ad05512.jpg"
     }
   ]


### PR DESCRIPTION
## Summary

Per requested cleanup, removed selected lower-signal entries:

- **Mentoring**: 12 → 5 (removed: "Mentoring an old class fellow…", "School Project Chat…", and the 5 individual "Google for Startups Mentoring (AI First SG)" startup sessions: Dimuto, Rabbit, Ailiverse, Storybrain, C2 Carbon Sync). Kept: Google AI First Accelerator Singapore + the 4 Solution Challenge Top-100 mentoring sessions.
- **Workshops**: 20 → 14 (removed: the two "Discovery Call" entries — Jaz, Rabbit; the three "Google for Startups Accelerator: Southeast Asia" entries — PasarMikro, Docosan, Noice; and "Women Developers Academy South-east Asia 2022"). Kept "Women Developer Academy Southeast-Asia 2021" and the Google Startup Jam 2019 workshop (retains its write-up link).

Data-only change: `src/data/mentoring.json` (`count` 5) and `src/data/workshops.json` (`count` 14). Branched fresh off `master` so the diff is exactly these two files.

## Verification

- `npm run check` → 0 errors / 0 warnings / 0 hints
- `npm test` → 14/14 (counts match each JSON `count`, sorted, GSJ workshop write-up link preserved)
- `npm run build` → exit 0; `/mentoring` 5 cards, `/workshops` 14 cards, `/talks` unchanged (35)

## Test plan

- [ ] `npm run dev` → confirm `/mentoring` and `/workshops` show only the kept items; removed titles absent